### PR TITLE
feat: implement route-based i18n (/en for English)

### DIFF
--- a/app/(clean-layout)/tag/TagContent.tsx
+++ b/app/(clean-layout)/tag/TagContent.tsx
@@ -14,7 +14,7 @@ interface TagContentProps {
 }
 
 export function TagContent({ articlesByLocale }: TagContentProps) {
-  const { locale } = useLocale();
+  const { locale, localePath } = useLocale();
   const allArticlesData = articlesByLocale[locale as keyof typeof articlesByLocale];
   
   // Flatten all tags from current locale articles
@@ -60,7 +60,7 @@ export function TagContent({ articlesByLocale }: TagContentProps) {
         {uniqueTags.map((tag) => (
           <Link
             key={tag}
-            href={`/tag/#${tag}`}
+            href={localePath(`/tag/#${tag}`)}
             onClick={() => handleTagClick(tag)}
             className="brand-badge flex gap-1 transition-colors hover:bg-brand-forest hover:text-white"
           >
@@ -96,7 +96,8 @@ export function TagContent({ articlesByLocale }: TagContentProps) {
               .map((article) => (
                 <div key={article.id}>
                   <article>
-                    <Link href={`/articles/${article.id}`}>
+                    <Link href={localePath(`/articles/${article.id}`)}>
+
                       <h3 className="mb-1 text-base hover:text-brand-accent dark:hover:text-brand-accent">
                         {article.title}
                       </h3>

--- a/app/(home-layout)/search/SearchArticle.tsx
+++ b/app/(home-layout)/search/SearchArticle.tsx
@@ -12,7 +12,7 @@ export const Search: React.FC<{
     en: ArticleData[];
   };
 }> = (props) => {
-  const { locale, t } = useLocale();
+  const { locale, t, localePath } = useLocale();
   const articles = props.articlesByLocale[locale as keyof typeof props.articlesByLocale];
 
   const { result, highlightedText, search, highlightText } = useSearch(
@@ -39,7 +39,7 @@ export const Search: React.FC<{
       </div>
       <div className="space-y-6">
         {result.map(({ id, title, content, date, tags }) => (
-          <Link href={`/articles/${id}`} key={id} className="group block">
+          <Link href={localePath(`/articles/${id}`)} key={id} className="group block">
             <article className="brand-article-card">
               <h3 className="mb-2 text-lg font-semibold text-brand-text-primary transition-colors group-hover:text-brand-accent dark:text-brand-dark-text">
                 {highlightText(title, highlightedText)}

--- a/app/[locale]/(clean-layout)/about/page.tsx
+++ b/app/[locale]/(clean-layout)/about/page.tsx
@@ -1,0 +1,11 @@
+import { Metadata } from "next";
+import AboutContent from "@/app/components/AboutContent";
+
+export const metadata: Metadata = {
+  title: "About - I Putu Deta Utama Putra",
+  description: "Meet Deta — a developer, father, and thinker from Bali.",
+};
+
+export default function Page() {
+  return <AboutContent />;
+}

--- a/app/[locale]/(clean-layout)/activity/page.tsx
+++ b/app/[locale]/(clean-layout)/activity/page.tsx
@@ -1,0 +1,34 @@
+import { Metadata } from "next";
+import { activities } from "@/app/(clean-layout)/activity/activityData";
+import { ActivityCard } from "@/app/(clean-layout)/activity/ActivityCard";
+
+export const metadata: Metadata = {
+  title: "Activity - I Putu Deta Utama Putra",
+  description:
+    "A personal activity and bookmark archive — things I explore, tools I use, and projects I follow.",
+};
+
+export default function Page() {
+  return (
+    <div>
+      <h1 className="text-center text-2xl font-bold">Activity</h1>
+      <div className="mb-5" />
+      <p>
+        A personal feed of things I find interesting, tools I explore, and
+        projects I follow.
+      </p>
+      <div className="mb-5" />
+      {activities.length === 0 ? (
+        <div className="py-16 text-center text-brand-text-secondary dark:text-brand-dark-text/50">
+          <p>No activities yet. Check back soon.</p>
+        </div>
+      ) : (
+        <div className="flex flex-col gap-4">
+          {activities.map((activity) => (
+            <ActivityCard key={activity.title} activity={activity} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/[locale]/(clean-layout)/articles/[articleId]/page.tsx
+++ b/app/[locale]/(clean-layout)/articles/[articleId]/page.tsx
@@ -1,0 +1,50 @@
+import { getAllArticleIds, getArticleData } from "@/app/lib/articles";
+import fs from "node:fs";
+import path from "node:path";
+import { Metadata } from "next";
+import ArticleContent from "@/app/components/ArticleContent";
+
+type Props = {
+  params: Promise<{ locale: string; articleId: string }>;
+};
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { articleId } = await params;
+  const articleData = getArticleData(articleId, "en");
+  return {
+    title: articleData.title,
+    description: articleData.description,
+    openGraph: {
+      images: `/og-images/${articleId}.png`,
+    },
+  };
+}
+
+export default async function Page({
+  params,
+}: {
+  readonly params: Promise<{
+    readonly locale: string;
+    readonly articleId: string;
+  }>;
+}) {
+  const { articleId } = await params;
+  const articleIdData = getArticleData(articleId, "id");
+  const articleEnData = getArticleData(articleId, "en");
+  const hasImage = fs.existsSync(
+    path.join(process.cwd(), "public", "og-images", `${articleId}.png`)
+  );
+
+  return (
+    <ArticleContent
+      articleId={articleId}
+      articlesByLocale={{ id: articleIdData, en: articleEnData }}
+      hasImage={hasImage}
+    />
+  );
+}
+
+export async function generateStaticParams() {
+  const allArticlesId = getAllArticleIds();
+  return allArticlesId.map((articleId) => ({ articleId }));
+}

--- a/app/[locale]/(clean-layout)/contact/page.tsx
+++ b/app/[locale]/(clean-layout)/contact/page.tsx
@@ -1,0 +1,26 @@
+import { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "Contact - I Putu Deta Utama Putra",
+  description: "Contact I Putu Deta Utama Putra",
+};
+
+export default function Page() {
+  return (
+    <div>
+      <h1 className="mb-4 text-center text-2xl font-bold">Contact</h1>
+      <p className="mb-4 text-center md:text-left">
+        I welcome feedback, suggestions, and constructive criticism. If you have
+        ideas to share or resources you think might be helpful, I&apos;d be happy to
+        hear from you.
+      </p>
+      <Link
+        href="mailto:detautama11@gmail.com"
+        className="block text-center text-xl text-blue-500"
+      >
+        Email to: detautama11@gmail.com
+      </Link>
+    </div>
+  );
+}

--- a/app/[locale]/(clean-layout)/layout.tsx
+++ b/app/[locale]/(clean-layout)/layout.tsx
@@ -1,0 +1,26 @@
+import type { Metadata } from "next";
+import "../../globals.css";
+import { Header } from "../../server-components/Header";
+import { TranslatedFooter } from "../../components/TranslatedFooter";
+
+export const metadata: Metadata = {
+  metadataBase: new URL("https://detautama.me/"),
+  title: "I Putu Deta Utama Putra",
+  description: "Thoughts on life, code, and everything in between",
+};
+
+export default function CleanLocaleLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return (
+    <div>
+      <Header />
+      <main className="brand-container min-h-screen py-8 pb-32 md:pb-8">
+        <div className="mx-auto max-w-prose">{children}</div>
+      </main>
+      <TranslatedFooter />
+    </div>
+  );
+}

--- a/app/[locale]/(clean-layout)/links/page.tsx
+++ b/app/[locale]/(clean-layout)/links/page.tsx
@@ -1,0 +1,38 @@
+import Link from "next/link";
+import { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Links - I Putu Deta Utama Putra",
+  description: "Other links that you might be interested in.",
+};
+
+export default function Page() {
+  return (
+    <div>
+      <h1 className="text-center text-2xl font-bold">Other links</h1>
+      <div className="mb-5" />
+      <p className="text-center md:text-left">
+        Here are some other links that you might be interested in.
+      </p>
+      <div className="mb-5" />
+
+      <div className="mb-5">
+        <Link href={"/en/achievements"} className="text-blue-500">
+          Achievements
+        </Link>
+        <div className="text-gray-500 dark:text-gray-300">
+          {`List of my achievements that I've done in the past.`}
+        </div>
+      </div>
+
+      <div className="mb-5">
+        <Link href={"/en/gallery"} className="text-blue-500">
+          Gallery
+        </Link>
+        <div className="text-gray-500 dark:text-gray-300">
+          Gallery of Celuk, a village in Bali, Indonesia.
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/[locale]/(clean-layout)/projects/page.tsx
+++ b/app/[locale]/(clean-layout)/projects/page.tsx
@@ -1,0 +1,23 @@
+import { Metadata } from "next";
+import { Porjects } from "@/app/(clean-layout)/projects/project";
+
+export const metadata: Metadata = {
+  title: "Projects - I Putu Deta Utama Putra",
+  description: "A collection of projects worked on by I Putu Deta Utama Putra",
+};
+
+export default function Page() {
+  return (
+    <div>
+      <h1 className="text-center text-2xl font-bold">Projects</h1>
+      <div className="mb-5" />
+      <p>
+        {
+          "These are some of the projects I've worked on in my spare time. Most of these projects are not open source. However, I'd be happy to share insights or discuss them further if you're interested."
+        }
+      </p>
+      <div className="mb-5" />
+      <Porjects />
+    </div>
+  );
+}

--- a/app/[locale]/(clean-layout)/tag/page.tsx
+++ b/app/[locale]/(clean-layout)/tag/page.tsx
@@ -1,0 +1,19 @@
+import { getSortedArticlesData } from "@/app/lib/articles";
+import { Metadata } from "next";
+import { TagContent } from "@/app/(clean-layout)/tag/TagContent";
+
+export const metadata: Metadata = {
+  title: "Tags - I Putu Deta Utama Putra",
+  description: "A collection of tags used in articles",
+};
+
+export default async function Page() {
+  const articlesId = getSortedArticlesData("id");
+  const articlesEn = getSortedArticlesData("en");
+
+  return (
+    <div>
+      <TagContent articlesByLocale={{ id: articlesId, en: articlesEn }} />
+    </div>
+  );
+}

--- a/app/[locale]/(home-layout)/layout.tsx
+++ b/app/[locale]/(home-layout)/layout.tsx
@@ -1,0 +1,24 @@
+import type { Metadata } from "next";
+import "../../globals.css";
+import { Header } from "../../server-components/Header";
+import { TranslatedFooter } from "../../components/TranslatedFooter";
+
+export const metadata: Metadata = {
+  metadataBase: new URL("https://detautama.me/"),
+  title: "I Putu Deta Utama Putra",
+  description: "Thoughts on life, code, and everything in between",
+};
+
+export default function HomeLocaleLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return (
+    <div>
+      <Header />
+      <main className="min-h-screen pb-24 md:pb-0">{children}</main>
+      <TranslatedFooter />
+    </div>
+  );
+}

--- a/app/[locale]/(home-layout)/page.tsx
+++ b/app/[locale]/(home-layout)/page.tsx
@@ -1,0 +1,21 @@
+import { getSortedArticlesData, getAllArticleIds } from "@/app/lib/articles";
+import { Metadata } from "next";
+import HomeContent from "@/app/components/HomeContent";
+
+export const metadata: Metadata = {
+  title: "Articles - I Putu Deta Utama Putra",
+  description: "A collection of articles written by I Putu Deta Utama Putra",
+};
+
+export default async function Page() {
+  const articlesId = getSortedArticlesData("id");
+  const articlesEn = getSortedArticlesData("en");
+  const articleIds = getAllArticleIds();
+
+  return (
+    <HomeContent
+      articlesByLocale={{ id: articlesId, en: articlesEn }}
+      articleIds={articleIds}
+    />
+  );
+}

--- a/app/[locale]/(home-layout)/search/page.tsx
+++ b/app/[locale]/(home-layout)/search/page.tsx
@@ -1,0 +1,9 @@
+import { getSortedArticlesData } from "@/app/lib/articles";
+import { Search } from "@/app/(home-layout)/search/SearchArticle";
+
+export default function Page() {
+  const articlesId = getSortedArticlesData("id");
+  const articlesEn = getSortedArticlesData("en");
+
+  return <Search articlesByLocale={{ id: articlesId, en: articlesEn }} />;
+}

--- a/app/[locale]/(wide-layout)/achievements/page.tsx
+++ b/app/[locale]/(wide-layout)/achievements/page.tsx
@@ -1,0 +1,1 @@
+export { default } from "@/app/(wide-layout)/achievements/page";

--- a/app/[locale]/(wide-layout)/gallery/page.tsx
+++ b/app/[locale]/(wide-layout)/gallery/page.tsx
@@ -1,0 +1,1 @@
+export { default } from "@/app/(wide-layout)/gallery/page";

--- a/app/[locale]/(wide-layout)/layout.tsx
+++ b/app/[locale]/(wide-layout)/layout.tsx
@@ -1,0 +1,26 @@
+import type { Metadata } from "next";
+import "../../globals.css";
+import { Header } from "../../server-components/Header";
+import { TranslatedFooter } from "../../components/TranslatedFooter";
+
+export const metadata: Metadata = {
+  metadataBase: new URL("https://detautama.me/"),
+  title: "I Putu Deta Utama Putra",
+  description: "Thoughts on life, code, and everything in between",
+};
+
+export default function WideLocaleLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return (
+    <div>
+      <Header />
+      <main className="brand-container min-h-screen py-8 pb-32 md:pb-8">
+        {children}
+      </main>
+      <TranslatedFooter />
+    </div>
+  );
+}

--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -1,0 +1,21 @@
+import { LocaleProvider } from "../lib/LocaleContext";
+import type { Locale } from "../lib/i18n";
+
+export function generateStaticParams() {
+  return [{ locale: "en" }];
+}
+
+export default async function LocaleLayout({
+  children,
+  params,
+}: {
+  children: React.ReactNode;
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+  const validLocale: Locale = locale === "en" ? "en" : "id";
+
+  return (
+    <LocaleProvider initialLocale={validLocale}>{children}</LocaleProvider>
+  );
+}

--- a/app/components/AboutContent.tsx
+++ b/app/components/AboutContent.tsx
@@ -5,7 +5,7 @@ import Link from "next/link";
 import { useLocale } from "../lib/LocaleContext";
 
 export default function AboutContent() {
-  const { locale } = useLocale();
+  const { locale, localePath } = useLocale();
 
   if (locale === "en") {
     return (
@@ -74,7 +74,7 @@ export default function AboutContent() {
             <p className="text-sm text-brand-text-secondary">
               Want to discuss something or just say hi? 
               Please send an email to <a href="mailto:detautama11@gmail.com" className="text-brand-accent hover:underline">detautama11@gmail.com</a>. 
-              Or check the <Link href="/contact" className="text-brand-accent hover:underline">/contact</Link> page for more details.
+              Or check the <Link href={localePath("/contact")} className="text-brand-accent hover:underline">/contact</Link> page for more details.
             </p>
           </div>
         </div>
@@ -150,7 +150,7 @@ export default function AboutContent() {
           <p className="text-sm text-brand-text-secondary">
             Ingin berdiskusi atau sekadar menyapa? 
             Silakan kirim email ke <a href="mailto:detautama11@gmail.com" className="text-brand-accent hover:underline">detautama11@gmail.com</a>. 
-            Atau cek halaman <Link href="/contact" className="text-brand-accent hover:underline">/contact</Link> untuk detail lebih lanjut.
+            Atau cek halaman <Link href={localePath("/contact")} className="text-brand-accent hover:underline">/contact</Link> untuk detail lebih lanjut.
           </p>
         </div>
       </div>

--- a/app/components/ArticleContent.tsx
+++ b/app/components/ArticleContent.tsx
@@ -20,7 +20,7 @@ interface ArticleContentProps {
 }
 
 export default function ArticleContent({ articleId, articlesByLocale, hasImage }: ArticleContentProps) {
-  const { locale, t } = useLocale();
+  const { locale, t, localePath } = useLocale();
 
   const articleData = articlesByLocale[locale];
   const isLanguageMissing = !articleData.availableLocales.includes(locale);
@@ -39,7 +39,7 @@ export default function ArticleContent({ articleId, articlesByLocale, hasImage }
           {articleData.tags.map((tag) => (
             <Link
               key={tag}
-              href={`/tag/#${tag}`}
+              href={localePath(`/tag/#${tag}`)}
               className="brand-badge flex gap-1 transition-colors hover:bg-brand-forest hover:text-white"
             >
               <Image src="/images/tag.svg" alt="tag" width={16} height={16} />

--- a/app/components/FeelingLuckyButton.tsx
+++ b/app/components/FeelingLuckyButton.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
+import { useLocale } from "../lib/LocaleContext";
 
 interface FeelingLuckyButtonProps {
   articleIds: string[];
@@ -10,13 +11,14 @@ export default function FeelingLuckyButton({
   articleIds,
 }: FeelingLuckyButtonProps) {
   const router = useRouter();
+  const { localePath } = useLocale();
 
   const handleClick = () => {
     if (articleIds.length === 0) return;
 
     const randomIndex = Math.floor(Math.random() * articleIds.length);
     const randomArticleId = articleIds[randomIndex];
-    router.push(`/articles/${randomArticleId}`);
+    router.push(localePath(`/articles/${randomArticleId}`));
   };
 
   return (

--- a/app/components/HomeContent.tsx
+++ b/app/components/HomeContent.tsx
@@ -15,19 +15,19 @@ interface HomeContentProps {
 }
 
 export default function HomeContent({ articlesByLocale, articleIds }: HomeContentProps) {
-  const { locale, t } = useLocale();
+  const { locale, t, localePath } = useLocale();
 
   const allArticlesData = articlesByLocale[locale];
-  
-  const featuredArticles = useMemo(() => 
+
+  const featuredArticles = useMemo(() =>
     allArticlesData.filter((article) => article.featured),
     [allArticlesData]
   );
 
   const links = [
-    { href: "/tag", label: t.home.quickLinks.browse, icon: "tag" },
-    { href: "/contact", label: t.home.quickLinks.contact, icon: "mail" },
-    { href: "/links", label: t.home.quickLinks.links, icon: "link" },
+    { href: localePath("/tag"), label: t.home.quickLinks.browse, icon: "tag" },
+    { href: localePath("/contact"), label: t.home.quickLinks.contact, icon: "mail" },
+    { href: localePath("/links"), label: t.home.quickLinks.links, icon: "link" },
     {
       href: "https://www.youtube.com/@detautama9899",
       label: "YouTube",
@@ -81,7 +81,7 @@ export default function HomeContent({ articlesByLocale, articleIds }: HomeConten
           </div>
           <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
             {featuredArticles.map(({ id, title }) => (
-              <Link href={`/articles/${id}`} key={id} className="group">
+              <Link href={localePath(`/articles/${id}`)} key={id} className="group">
                 <div className="brand-featured-card flex h-32 items-center justify-center transition-all duration-300 group-hover:scale-[1.02] group-hover:shadow-xl">
                   <h3 className="line-clamp-3 px-4 text-center font-display font-medium text-brand-text-primary dark:text-brand-dark-text">
                     {title}
@@ -129,7 +129,7 @@ export default function HomeContent({ articlesByLocale, articleIds }: HomeConten
                   {date}
                 </time>
               </div>
-              <Link href={`/articles/${id}`}>
+              <Link href={localePath(`/articles/${id}`)}>
                 <h3 className="mb-2 font-display text-xl font-bold text-brand-text-primary transition-colors group-hover:text-brand-accent dark:text-brand-dark-text">
                   {title}
                 </h3>
@@ -142,14 +142,14 @@ export default function HomeContent({ articlesByLocale, articleIds }: HomeConten
                   {tags.map((tag) => (
                     <Link
                       key={tag}
-                      href={`/tag/#${tag}`}
+                      href={localePath(`/tag/#${tag}`)}
                       className="brand-badge transition-colors hover:bg-brand-forest hover:text-white"
                     >
                       {tag}
                     </Link>
                   ))}
                 </div>
-                <Link href={`/articles/${id}`} className="shrink-0 text-brand-accent transition-colors hover:text-brand-forest dark:hover:text-brand-accent/80">
+                <Link href={localePath(`/articles/${id}`)} className="shrink-0 text-brand-accent transition-colors hover:text-brand-forest dark:hover:text-brand-accent/80">
                   <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
                   </svg>

--- a/app/components/LanguageToggle.tsx
+++ b/app/components/LanguageToggle.tsx
@@ -1,13 +1,26 @@
 "use client";
 
+import Link from "next/link";
 import { useLocale } from "../lib/LocaleContext";
+import { usePathname } from "next/navigation";
 
 export function LanguageToggle() {
-  const { locale, setLocale } = useLocale();
+  const { locale } = useLocale();
+  const pathname = usePathname();
+
+  const getAlternateUrl = () => {
+    if (locale === "id") {
+      if (pathname === "/") return "/en";
+      return `/en${pathname}`;
+    } else {
+      const withoutLocale = pathname.replace(/^\/en/, "");
+      return withoutLocale || "/";
+    }
+  };
 
   return (
-    <button
-      onClick={() => setLocale(locale === "id" ? "en" : "id")}
+    <Link
+      href={getAlternateUrl()}
       className="group flex items-center gap-2 rounded-lg bg-brand-tan p-2 transition-all duration-200 hover:bg-brand-forest hover:text-white dark:bg-brand-dark-surface dark:hover:bg-brand-dark-border"
       aria-label="Change Language"
     >
@@ -27,6 +40,6 @@ export function LanguageToggle() {
           d="M3 5h12M9 3v2m1.048 9.5A18.022 18.022 0 016.412 9m6.088 9h7M11 21l5-10 5 10M12.751 5C11.783 11.37 9.188 16.524 5.5 20"
         />
       </svg>
-    </button>
+    </Link>
   );
 }

--- a/app/lib/LocaleContext.tsx
+++ b/app/lib/LocaleContext.tsx
@@ -7,35 +7,53 @@ interface LocaleContextType {
   locale: Locale;
   setLocale: (locale: Locale) => void;
   t: Translations;
+  localePath: (path: string) => string;
 }
 
 const LocaleContext = createContext<LocaleContextType | undefined>(undefined);
 
-export function LocaleProvider({ children }: { children: React.ReactNode }) {
-  const [locale, setLocaleState] = useState<Locale>("id");
+export function LocaleProvider({
+  children,
+  initialLocale,
+}: {
+  children: React.ReactNode;
+  initialLocale?: Locale;
+}) {
+  const [locale, setLocaleState] = useState<Locale>(initialLocale ?? "id");
 
   useEffect(() => {
+    if (initialLocale) {
+      setLocaleState(initialLocale);
+      return;
+    }
     const savedLocale = localStorage.getItem("locale") as Locale;
     if (savedLocale && (savedLocale === "id" || savedLocale === "en")) {
       setLocaleState(savedLocale);
     } else {
-      // Try to detect browser locale
       const browserLang = navigator.language.split("-")[0];
       if (browserLang === "en") {
         setLocaleState("en");
       }
     }
-  }, []);
+  }, [initialLocale]);
 
   const setLocale = (newLocale: Locale) => {
-    setLocaleState(newLocale);
-    localStorage.setItem("locale", newLocale);
+    if (!initialLocale) {
+      setLocaleState(newLocale);
+      localStorage.setItem("locale", newLocale);
+    }
+  };
+
+  const localePath = (path: string) => {
+    if (locale === "id") return path;
+    if (path === "/") return "/en";
+    return `/en${path}`;
   };
 
   const t = translations[locale];
 
   return (
-    <LocaleContext.Provider value={{ locale, setLocale, t }}>
+    <LocaleContext.Provider value={{ locale, setLocale, t, localePath }}>
       {children}
     </LocaleContext.Provider>
   );

--- a/app/server-components/Header.tsx
+++ b/app/server-components/Header.tsx
@@ -9,12 +9,16 @@ import { LanguageToggle } from "../components/LanguageToggle";
 
 export const Header = () => {
   const pathname = usePathname();
-  const { t } = useLocale();
+  const { t, localePath } = useLocale();
+
+  const basePath = pathname.startsWith("/en")
+    ? pathname.slice(3) || "/"
+    : pathname;
 
   const isActive = (path: string) => {
-    if (path === "/" && pathname === "/") return true;
-    if (path === "/" && pathname.startsWith("/articles")) return true;
-    if (path !== "/" && pathname.startsWith(path)) return true;
+    if (path === "/" && (basePath === "/" || basePath.startsWith("/articles")))
+      return true;
+    if (path !== "/" && basePath.startsWith(path)) return true;
     return false;
   };
 
@@ -24,7 +28,7 @@ export const Header = () => {
         <div className="brand-container">
           <div className="flex h-16 items-center justify-between">
             <div className="flex items-center space-x-8">
-              <Link href="/" className="group flex items-center space-x-3">
+              <Link href={localePath("/")} className="group flex items-center space-x-3">
                 <div className="relative">
                   <Image
                     className="rounded-full transition-transform duration-200 group-hover:scale-105"
@@ -47,7 +51,7 @@ export const Header = () => {
 
               <nav className="hidden items-center space-x-1 md:flex">
                 <Link
-                  href="/"
+                  href={localePath("/")}
                   className={`brand-nav-link ${
                     isActive("/") ? "text-brand-accent" : ""
                   }`}
@@ -55,7 +59,7 @@ export const Header = () => {
                   {t.nav.articles}
                 </Link>
                 <Link
-                  href="/projects"
+                  href={localePath("/projects")}
                   className={`brand-nav-link ${
                     isActive("/projects") ? "text-brand-accent" : ""
                   }`}
@@ -63,7 +67,7 @@ export const Header = () => {
                   {t.nav.projects}
                 </Link>
                 <Link
-                  href="/about"
+                  href={localePath("/about")}
                   className={`brand-nav-link ${
                     isActive("/about") ? "text-brand-accent" : ""
                   }`}
@@ -71,7 +75,7 @@ export const Header = () => {
                   {t.nav.about}
                 </Link>
                 <Link
-                  href="/tag"
+                  href={localePath("/tag")}
                   className={`brand-nav-link ${
                     isActive("/tag") ? "text-brand-accent" : ""
                   }`}
@@ -79,7 +83,7 @@ export const Header = () => {
                   {t.nav.tags}
                 </Link>
                 <Link
-                  href="/activity"
+                  href={localePath("/activity")}
                   className={`brand-nav-link ${
                     isActive("/activity") ? "text-brand-accent" : ""
                   }`}
@@ -91,7 +95,7 @@ export const Header = () => {
 
             <div className="flex items-center space-x-4">
               <Link
-                href="/search"
+                href={localePath("/search")}
                 className="rounded-lg p-2 transition-colors duration-200 hover:bg-brand-tan dark:hover:bg-brand-dark-surface"
               >
                 <svg
@@ -119,7 +123,7 @@ export const Header = () => {
       <nav className="fixed bottom-0 left-0 right-0 z-50 border-t border-white/20 bg-brand-cream/80 shadow-[0_-4px_16px_rgba(0,0,0,0.1)] backdrop-blur-xl md:hidden dark:border-white/10 dark:bg-brand-dark-bg/70 dark:shadow-[0_-4px_16px_rgba(0,0,0,0.3)]">
         <div className="flex items-center justify-around bg-gradient-to-t from-brand-cream/10 to-transparent py-2 dark:from-white/5 dark:to-transparent">
           <Link
-            href="/"
+            href={localePath("/")}
             className={`flex flex-col items-center px-3 py-1 transition-colors ${
               isActive("/")
                 ? "text-brand-accent"
@@ -142,7 +146,7 @@ export const Header = () => {
             <span className="text-xs font-medium">{t.nav.articles}</span>
           </Link>
           <Link
-            href="/projects"
+            href={localePath("/projects")}
             className={`flex flex-col items-center px-3 py-1 transition-colors ${
               isActive("/projects")
                 ? "text-brand-accent"
@@ -165,7 +169,7 @@ export const Header = () => {
             <span className="text-xs font-medium">{t.nav.projects}</span>
           </Link>
           <Link
-            href="/about"
+            href={localePath("/about")}
             className={`flex flex-col items-center px-3 py-1 transition-colors ${
               isActive("/about")
                 ? "text-brand-accent"
@@ -188,7 +192,7 @@ export const Header = () => {
             <span className="text-xs font-medium">{t.nav.about}</span>
           </Link>
           <Link
-            href="/tag"
+            href={localePath("/tag")}
             className={`flex flex-col items-center px-3 py-1 transition-colors ${
               isActive("/tag")
                 ? "text-brand-accent"
@@ -211,7 +215,7 @@ export const Header = () => {
             <span className="text-xs font-medium">{t.nav.tags}</span>
           </Link>
           <Link
-            href="/activity"
+            href={localePath("/activity")}
             className={`flex flex-col items-center px-3 py-1 transition-colors ${
               isActive("/activity")
                 ? "text-brand-accent"


### PR DESCRIPTION
Implements route-based i18n as requested in issue #48.

## Changes

- `detautama.me/` → Indonesian (default, no prefix)
- `detautama.me/en` → English home
- `detautama.me/en/articles/[id]` → English article
- All other pages available under `/en/` prefix

Adds `[locale]` dynamic segment generating only English pages. URL determines locale instead of localStorage. Language toggle navigates between routes.

Generated with [Claude Code](https://claude.ai/code)