### PR TITLE
fix: add missing Open Graph tags

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -26,6 +26,15 @@ export const metadata: Metadata = {
   metadataBase: new URL("https://detautama.me/"),
   title: "I Putu Deta Utama Putra",
   description: "Thoughts on life, code, and everything in between.",
+  openGraph: {
+    url: "https://detautama.me/",
+    type: "website",
+    title: "I Putu Deta Utama Putra",
+    description: "Thoughts on life, code, and everything in between.",
+  },
+  other: {
+    "og:logo": "https://detautama.me/deta.png",
+  },
 };
 
 export default function RootLayout({


### PR DESCRIPTION
Adds the missing `og:url`, `og:type`, and `og:logo` tags to the root layout metadata.

Closes #54

Generated with [Claude Code](https://claude.ai/code)